### PR TITLE
Allow access to the admin console

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apk add --update curl && \
     mkdir -p /opt && \
     curl -s -S https://archive.apache.org/dist/activemq/$ACTIVEMQ_VERSION/$ACTIVEMQ-bin.tar.gz | tar -xvz -C /opt && \
     ln -s /opt/$ACTIVEMQ $ACTIVEMQ_HOME && \
+    sed -i "s|127.0.0.1|0.0.0.0|g" $ACTIVEMQ_HOME/conf/jetty.xml && \
     addgroup -S activemq && \
     adduser -S -H -G activemq -h $ACTIVEMQ_HOME activemq && \
     chown -R activemq:activemq /opt/$ACTIVEMQ && \


### PR DESCRIPTION
The activemq container that startup does not allow user access to the admin console (which will be the http://<host>:8161/admin). Reason behind is that the jetty.xml by default only set to allow 127.0.0.1 (localhost) to access. 
Fix is just to update the jetty.xml to change all 127.0.0.1 to 0.0.0.0
More detail can check https://stackoverflow.com/questions/63127321/not-able-to-access-admin-console-for-an-activemq-instance-running-in-a-docker-co