### PR TITLE
make container configurable by env-vars fixes #6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,10 @@ RUN apk add --update curl && \
 
 EXPOSE 1883 5672 8161 61613 61614 61616
 
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
 USER activemq
 WORKDIR $ACTIVEMQ_HOME
 
-CMD ["/bin/sh", "-c", "bin/activemq console"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -8,11 +8,34 @@ Published on the Docker Hub: https://hub.docker.com/r/symptoma/activemq
 
 Current version of ActiveMQ is **5.17.1**: https://archive.apache.org/dist/activemq/5.17.1/
 
-Note: Since 5.16.0 the Web Console is not reachable by default, as it only listens to 127.0.0.1 inside the container. See [AMQ-8018](https://issues.apache.org/jira/browse/AMQ-8018) for more details.
+Note: Since ActiveMQ 5.15.0 the Web Console is not reachable by default, as it only listens to 127.0.0.1 inside the container. See [AMQ-8018](https://issues.apache.org/jira/browse/AMQ-8018) for more details.
+
+## Settings
+You can define the following environment variables to control the behavior. 
+
+| Environment Variable                    | Default | Description                                                                                                                                                                   |
+|:----------------------------------------|:--------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ACTIVEMQ_USERNAME                       | system  | [Security](https://activemq.apache.org/security) (credentials.properties)                                                                                                     |
+| ACTIVEMQ_PASSWORD                       | manager | [Security](https://activemq.apache.org/security) (credentials.properties)                                                                                                     |
+| ACTIVEMQ_WEBADMIN_USERNAME              | admin   | [WebConsole](https://activemq.apache.org/security) (jetty-realm.properties)                                                                                                   |
+| ACTIVEMQ_WEBADMIN_PASSWORD              | admin   | [WebConsole](https://activemq.apache.org/security) (jetty-realm.properties)                                                                                                   |
+| ACTIVEMQ_WEBCONSOLE_USE_DEFAULT_ADDRESS | false   | Set default behavior of ActiveMQ Jetty listen address (127.0.0.1). By default, WebConsole listens on all addresses (0.0.0.0), so you can reach/map the WebConsole port (8161) |
+
+## Exposed Ports
+The following ports are exposed and can be bound:
+
+| Port  | Description |
+|:------|:------------|
+| 1883  | MQTT        |
+| 5672  | AMPQ        |
+| 8161  | WebConsole  |
+| 61613 | STOMP       |
+| 61614 | WS          |
+| 61616 | OpenWire    |
 
 ## Build
 ```
-docker build -t symptoma/activemq .
+./build.sh
 ```
 
 ## Run
@@ -20,6 +43,19 @@ docker build -t symptoma/activemq .
 docker run -it -p 61616:61616 -p 8161:8161 symptoma/activemq:latest
 ```
 Bind more ports if you need to.
+
+Example with environment variables:
+```
+docker run -it \
+-p 61616:61616 \
+-p 8161:8161 \
+-e ACTIVEMQ_DISALLOW_WEBCONSOLE=false \
+-e ACTIVEMQ_USERNAME=myactivemquser \
+-e ACTIVEMQ_PASSWORD=myactivemquserpass \
+-e ACTIVEMQ_WEBADMIN_USERNAME=roos \
+-e ACTIVEMQ_WEBADMIN_PASSWORD=TestTest \
+symptoma/activemq:latest
+```
 
 ## Publish
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+docker rmi symptoma/activemq
+docker build -t symptoma/activemq .

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+activemq_webadmin_username="admin"
+activemq_webadmin_pw="admin"
+
+## Modify jetty.xml
+
+# WebConsole to listen on all addresses (beginning with 2.17, it listens on 127.0.0.1 by default, so is unreachable in Container)
+# Bind to all addresses by default. Can be disabled setting ACTIVEMQ_WEBCONSOLE_USE_DEFAULT_ADDRESS=true
+if [ ! "$ACTIVEMQ_WEBCONSOLE_USE_DEFAULT_ADDRESS" == "true" ]; then
+  echo "Allowing WebConsole listen to 0.0.0.0"
+  sed -i 's#<property name="host" value="127.0.0.1"/>#<property name="host" value="0.0.0.0"/>#' conf/jetty.xml
+fi
+
+if [ -n "$ACTIVEMQ_USERNAME" ]; then
+  echo "Setting activemq username to $ACTIVEMQ_USERNAME"
+  sed -i "s#activemq.username=system#activemq.username=$ACTIVEMQ_USERNAME#" conf/credentials.properties
+fi
+
+
+if [ -n "$ACTIVEMQ_PASSWORD" ]; then
+  echo "Setting activemq password"
+  sed -i "s#activemq.password=manager#activemq.password=$ACTIVEMQ_PASSWORD#" conf/credentials.properties
+fi
+
+if [ -n "$ACTIVEMQ_WEBADMIN_USERNAME" ]; then
+  activemq_webadmin_username=$ACTIVEMQ_WEBADMIN_USERNAME
+  has_modified_webadmin_username="username"
+fi
+
+if [ -n "$ACTIVEMQ_WEBADMIN_PASSWORD" ]; then
+  activemq_webadmin_pw="$ACTIVEMQ_WEBADMIN_PASSWORD"
+  has_modified_webadmin_pw=" and password"
+fi
+
+if [ -n "$ACTIVEMQ_WEBADMIN_USERNAME"  ] || [ -n "$ACTIVEMQ_WEBADMIN_PASSWORD" ]; then
+    echo "Setting activemq WebConsole $has_modified_webadmin_username $has_modified_webadmin_pw"
+    sed -i "s#admin: admin, admin#$activemq_webadmin_username: $activemq_webadmin_pw, admin#" conf/jetty-realm.properties
+fi
+
+# Start
+bin/activemq console


### PR DESCRIPTION
- Set the WebConsole port to listen to 0.0.0.0 by default (since 2.15.x it listens on 127.0.0.1, only)
- Default behaviour can be set by ACTIVEMQ_WEBCONSOLE_USE_DEFAULT_ADDRESS=true
- Make some of the other configs configurable by env vars (users)