### PR TITLE
Add env vars to change contextPaths for /api and /admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ You can define the following environment variables to control the behavior.
 | ACTIVEMQ_WEBADMIN_USERNAME              | admin   | [WebConsole](https://activemq.apache.org/security) (jetty-realm.properties)                                                                                                   |
 | ACTIVEMQ_WEBADMIN_PASSWORD              | admin   | [WebConsole](https://activemq.apache.org/security) (jetty-realm.properties)                                                                                                   |
 | ACTIVEMQ_WEBCONSOLE_USE_DEFAULT_ADDRESS | false   | Set default behavior of ActiveMQ Jetty listen address (127.0.0.1). By default, WebConsole listens on all addresses (0.0.0.0), so you can reach/map the WebConsole port (8161) |
+| ACTIVEMQ_ADMIN_CONTEXTPATH              | /admin  | [WebConsole](https://github.com/apache/activemq/blob/main/assembly/src/release/conf/jetty.xml) Set contextPath of WebConsole (jetty.xml)                                      |
+| ACTIVEMQ_API_CONTEXTPATH                | /api    | [API](https://github.com/apache/activemq/blob/main/assembly/src/release/conf/jetty.xml) Set contextPath of API (jetty.xml)                                                    |
+
 
 ## Exposed Ports
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,11 +12,20 @@ if [ ! "$ACTIVEMQ_WEBCONSOLE_USE_DEFAULT_ADDRESS" == "true" ]; then
   sed -i 's#<property name="host" value="127.0.0.1"/>#<property name="host" value="0.0.0.0"/>#' conf/jetty.xml
 fi
 
+if [ -n "$ACTIVEMQ_ADMIN_CONTEXTPATH" ]; then
+  echo "Setting activemq admin contextPath to $ACTIVEMQ_ADMIN_CONTEXTPATH"
+  sed -iv "s#<property name=\"contextPath\" value=\"/admin\" />#<property name=\"contextPath\" value=\"${ACTIVEMQ_ADMIN_CONTEXTPATH}\" />#" conf/jetty.xml
+fi
+
+if [ -n "$ACTIVEMQ_API_CONTEXTPATH" ]; then
+  echo "Setting activemq API contextPath to $ACTIVEMQ_API_CONTEXTPATH"
+  sed -iv "s#<property name=\"contextPath\" value=\"/api\" />#<property name=\"contextPath\" value=\"${ACTIVEMQ_API_CONTEXTPATH}\" />#" conf/jetty.xml
+fi
+
 if [ -n "$ACTIVEMQ_USERNAME" ]; then
   echo "Setting activemq username to $ACTIVEMQ_USERNAME"
   sed -i "s#activemq.username=system#activemq.username=$ACTIVEMQ_USERNAME#" conf/credentials.properties
 fi
-
 
 if [ -n "$ACTIVEMQ_PASSWORD" ]; then
   echo "Setting activemq password"


### PR DESCRIPTION
As usual: Default behavior does not change, but one got the option to change /api and/or /admin context paths.
This is especially useful if you run a lot of containers on the same host fronted by a SSL proxy server.