### PR TITLE
Update ActiveMQ to 5.18.3 (critical security fix)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM bellsoft/liberica-openjdk-alpine:17
 
 LABEL maintainer="Thomas Lutz <lutz@symptoma.com>"
 
-ENV ACTIVEMQ_VERSION 5.18.2
+ENV ACTIVEMQ_VERSION 5.18.3
 ENV ACTIVEMQ apache-activemq-$ACTIVEMQ_VERSION
 ENV ACTIVEMQ_HOME /opt/activemq
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ symptoma/activemq:latest
 
 ## ActiveMQ version
 
-Current version of ActiveMQ is **5.18.2**: https://archive.apache.org/dist/activemq/5.18.2/
+Current version of ActiveMQ is **5.18.3**: https://archive.apache.org/dist/activemq/5.18.3/
 
 Note: Since ActiveMQ 5.16.0 the Web Console is not reachable by default, as it only listens to 127.0.0.1 inside the container. See [AMQ-8018](https://issues.apache.org/jira/browse/AMQ-8018) for more details.
 
@@ -69,11 +69,11 @@ The following ports are exposed and can be bound:
 
 First, commit your change to Git. 
 
-`git commit -m "Update ActiveMQ to 5.18.2"`
+`git commit -m "Update ActiveMQ to 5.18.3"`
 
 Then tag it. 
 
-`git tag -a v5.18.2 -m 'Release 5.18.2'`
+`git tag -a v5.18.3 -m 'Release 5.18.3'`
 
 Then push it to Github.
 
@@ -82,7 +82,7 @@ Then push it to Github.
 Publishing manually works like this (after `docker login`):
 
 ```
-docker tag <image> symptoma/activemq:5.18.2
+docker tag <image> symptoma/activemq:5.18.3
 docker push symptoma/activemq
 ```
 
@@ -94,5 +94,5 @@ Prepare the buildx context and use it:
 
 Then build for multiple platforms:
 
-* `docker buildx build --push --platform linux/arm64,linux/amd64 --tag symptoma/activemq:5.18.2 .`
+* `docker buildx build --push --platform linux/arm64,linux/amd64 --tag symptoma/activemq:5.18.3 .`
 * `docker buildx build --push --platform linux/arm64,linux/amd64 --tag symptoma/activemq:latest .`


### PR DESCRIPTION
Fixes CVE-2023-46604, a critical RCE vulnerability in AMQ, see https://activemq.apache.org/security-advisories.data/CVE-2023-46604-announcement.txt

Tagging @tholu for visibility