### PR TITLE
Just updated to ActiveMQ Classic 6.0.0, tested the variables that are used in file entrypoint.sh and verify if they work.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM bellsoft/liberica-openjdk-alpine:17
 
 LABEL maintainer="Thomas Lutz <lutz@symptoma.com>"
 
-ENV ACTIVEMQ_VERSION 5.18.3
+ENV ACTIVEMQ_VERSION 6.0.0
 ENV ACTIVEMQ apache-activemq-$ACTIVEMQ_VERSION
 ENV ACTIVEMQ_HOME /opt/activemq
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -44,7 +44,18 @@ fi
 
 if [ -n "$ACTIVEMQ_WEBADMIN_USERNAME"  ] || [ -n "$ACTIVEMQ_WEBADMIN_PASSWORD" ]; then
   echo "Setting activemq WebConsole $has_modified_webadmin_username $has_modified_webadmin_pw"
-  sed -i "s#admin: admin, admin#$activemq_webadmin_username: $activemq_webadmin_pw, admin#" conf/jetty-realm.properties
+
+  # If file conf/jetty-realm.properties exists
+  if [[ -e conf/jetty-realm.properties ]]; then
+    sed -i "s#admin: admin, admin#$activemq_webadmin_username: $activemq_webadmin_pw, admin#" conf/jetty-realm.properties
+  fi
+
+  # If file conf/jetty-realm.properties not exists
+  if [[ ! -e conf/jetty-realm.properties ]]; then
+    mkdir -p conf
+    touch conf/jetty-realm.properties
+    echo "$activemq_webadmin_username: $activemq_webadmin_pw, admin" >> conf/jetty-realm.properties
+  fi
 fi
 
 ## Modify activemq.xml


### PR DESCRIPTION
It's need to fix the file entrypoint.sh too because the file "conf/jetty-realm.properties" doesn't exists on this version of ActiveMQ.